### PR TITLE
Fix field to show links for User relations

### DIFF
--- a/src/templates/fields/relations/_input.twig
+++ b/src/templates/fields/relations/_input.twig
@@ -23,12 +23,10 @@
     </tr>
     {% for item in relations %}
         <tr>
-            <td>{{ item.title }}</td>
+            <td>{{ item.title ? item.title : item.firstName and item.lastName ? item.firstName~' '~item.lastName }}</td>
             <td>{{ item.displayName() ?? "Unknown" }}</td>
             <td>
-              {% if item.hasUris() %}
-                <a href="{{ item.getCpEditUrl() }}">Show</a>
-              {% endif %}
+              <a href="{{ item.getCpEditUrl() }}">Show</a>
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
* Users do not have a title, just firstName and lastName.
* The check for hasUris() was too limited. It checks if the entry has a public URL, while in this context we just need to get a CP URL (which every entry should have..)