### PR TITLE
Fix #14

### DIFF
--- a/src/services/Relations.php
+++ b/src/services/Relations.php
@@ -25,7 +25,7 @@ class Relations extends Component
     {
         $relatedElements = [];
 
-        if ( !$element )
+        if ( !$element || !$element->id )
         {
             return [];
         }


### PR DESCRIPTION
I found what caused issue #14 (which isn't just about users actually, but any element type): before an element is saved, it exists but it doesn't have an ID, which means that the query to get the `$relatedIds` returned all the relations in the database. Changing the `if ( !$element )` check that returns early to `if ( !$element || !$element->id )` fixes it.

It also fixes a more important issue where if you have elements in the database from an old plugin that has since been uninstalled (as was my case with the Contact Form Extensions plugin), it would crash because `$elementsService->getElementById($id)` does `$elementType::find()` where `$elementType` is a non-existent class. Maybe Craft should be more defensive about it, but with this fix that code doesn't run anymore for those ghost elements, so it doesn't crash.

Thank you!